### PR TITLE
added section about updating node.js on ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ To update Node.js, manually add the 16.x repository as shown [here](https://gith
 ```bash
     curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
     sudo apt-get install -y nodejs
+```
+
 ## Notes on CentOS / RHEL 8.x builds
 
 Before starting the build

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Builds Vircadia (codename "Project Athena"), an Open Source fork of the High Fid
 * OpenSuSE Tumbleweed
 * (more coming soon)
 
+## Notes on Ubuntu 18.04
+
+The Node.js in Ubuntu's official repositories is severely outdated. This can lead to problems building target jsdoc.
+
+To update Node.js, manually add the 16.x repository as shown [here](https://github.com/nodesource/distributions)
+
+    curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+    sudo apt-get install -y nodejs
+
 ## Notes on CentOS / RHEL 8.x builds
 
 Before starting the build

--- a/README.md
+++ b/README.md
@@ -22,10 +22,9 @@ Builds Vircadia (codename "Project Athena"), an Open Source fork of the High Fid
 The Node.js in Ubuntu's official repositories is severely outdated. This can lead to problems building target jsdoc.
 
 To update Node.js, manually add the 16.x repository as shown [here](https://github.com/nodesource/distributions)
-
+```bash
     curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
     sudo apt-get install -y nodejs
-
 ## Notes on CentOS / RHEL 8.x builds
 
 Before starting the build


### PR DESCRIPTION
the node.js in ubuntu 18.04's official repos can't make jsdoc, on account of being several versions behind what jsdoc needs to be made.  this section instructs users on how to update node.js.